### PR TITLE
swap GuildCreate and Ready, fix auto-mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,8 @@ It is a known issue with a dependency of this project.
 
 Audio leveling from Discord needs to be improved.
 
+Delays in connecting to Mumble (such as from external authentication plugins) may result in extra error messages on initial connection.
+
 ## License
 
 Distributed under the MIT License. See LICENSE for more information.

--- a/bridge.go
+++ b/bridge.go
@@ -98,6 +98,7 @@ func (b *BridgeState) startBridge() {
 
 	if err != nil {
 		log.Println(err)
+		b.DiscordVoice.Disconnect()
 		return
 	}
 	defer b.MumbleClient.Disconnect()

--- a/bridge.go
+++ b/bridge.go
@@ -50,6 +50,9 @@ type BridgeState struct {
 	MumbleUsers      map[string]bool
 	MumbleUsersMutex sync.Mutex
 
+	// Total Number of Mumble users
+	MumbleUserCount int
+
 	// Kill the auto connect routine
 	AutoChanDie chan bool
 
@@ -129,14 +132,21 @@ func (b *BridgeState) startBridge() {
 		ticker := time.NewTicker(500 * time.Millisecond)
 		for {
 			<-ticker.C
-			if b.MumbleClient.State() != 2 {
-				log.Println("Lost mumble connection " + strconv.Itoa(int(b.MumbleClient.State())))
+			if b.MumbleClient == nil || b.MumbleClient.State() != 2 {
+				if b.MumbleClient != nil {
+					log.Println("Lost mumble connection " + strconv.Itoa(int(b.MumbleClient.State())))
+				} else {
+					log.Println("Lost mumble connection due to bridge dieing")
+					return
+				}
 				select {
-				default:
-					close(b.BridgeDie)
 				case <-b.BridgeDie:
 					//die is already closed
+
+				default:
+					close(b.BridgeDie)
 				}
+
 			}
 		}
 	}()
@@ -150,6 +160,7 @@ func (b *BridgeState) startBridge() {
 		det.Detach()
 		close(toDiscord)
 		close(toMumble)
+		close(b.BridgeDie)
 		b.Connected = false
 		b.DiscordVoice = nil
 		b.MumbleClient = nil
@@ -170,17 +181,17 @@ func (b *BridgeState) discordStatusUpdate() {
 			b.DiscordSession.UpdateListeningStatus("an error pinging mumble")
 		} else {
 			b.MumbleUsersMutex.Lock()
-			userCount := resp.ConnectedUsers
+			b.MumbleUserCount = resp.ConnectedUsers
 			if b.Connected {
-				userCount = userCount - 1
+				b.MumbleUserCount = b.MumbleUserCount - 1
 			}
-			if userCount == 0 {
+			if b.MumbleUserCount == 0 {
 				status = "No users in Mumble"
 			} else {
 				if len(b.MumbleUsers) > 0 {
-					status = fmt.Sprintf("%v/%v users in Mumble\n", len(b.MumbleUsers), userCount)
+					status = fmt.Sprintf("%v/%v users in Mumble\n", len(b.MumbleUsers), b.MumbleUserCount)
 				} else {
-					status = fmt.Sprintf("%v users in Mumble\n", userCount)
+					status = fmt.Sprintf("%v users in Mumble\n", b.MumbleUserCount)
 				}
 			}
 			b.MumbleUsersMutex.Unlock()
@@ -207,14 +218,13 @@ func (b *BridgeState) AutoBridge() {
 		b.MumbleUsersMutex.Lock()
 		b.DiscordUsersMutex.Lock()
 
-		if !b.Connected && len(b.MumbleUsers) > 0 && len(b.DiscordUsers) > 0 {
+		if !b.Connected && b.MumbleUserCount > 0 && len(b.DiscordUsers) > 0 {
 			log.Println("users detected in mumble and discord, bridging")
 			go b.startBridge()
 		}
-		if b.Connected && len(b.MumbleUsers) == 0 && len(b.DiscordUsers) <= 1 {
+		if b.Connected && b.MumbleUserCount == 0 && len(b.DiscordUsers) <= 1 {
 			log.Println("no one online, killing bridge")
 			b.BridgeDie <- true
-			b.BridgeDie = nil
 		}
 
 		b.MumbleUsersMutex.Unlock()

--- a/discord-handlers.go
+++ b/discord-handlers.go
@@ -15,25 +15,15 @@ type DiscordListener struct {
 	Bridge *BridgeState
 }
 
-func (l *DiscordListener) ready(s *discordgo.Session, event *discordgo.Ready) {
-	log.Println("READY event registered")
+func (l *DiscordListener) guildCreate(s *discordgo.Session, event *discordgo.GuildCreate) {
+	log.Println("CREATE event registered")
 
-	//Setup initial discord state
-	var g *discordgo.Guild
-	g = nil
-
-	for _, i := range event.Guilds {
-		if i.ID == l.Bridge.BridgeConfig.GID {
-			g = i
-		}
-	}
-
-	if g == nil {
-		log.Println("bad guild on READY")
+	if event.ID != l.Bridge.BridgeConfig.GID {
+		log.Println("received GuildCreate from a guild not in config")
 		return
 	}
 
-	for _, vs := range g.VoiceStates {
+	for _, vs := range event.VoiceStates {
 		if vs.ChannelID == l.Bridge.BridgeConfig.CID {
 			if s.State.User.ID == vs.UserID {
 				// Ignore bot
@@ -139,20 +129,6 @@ func (l *DiscordListener) messageCreate(s *discordgo.Session, m *discordgo.Messa
 		} else {
 			l.Bridge.AutoChanDie <- true
 			l.Bridge.Mode = bridgeModeManual
-		}
-	}
-}
-
-func (l *DiscordListener) guildCreate(s *discordgo.Session, event *discordgo.GuildCreate) {
-
-	if event.Guild.Unavailable {
-		return
-	}
-
-	for _, channel := range event.Guild.Channels {
-		if channel.ID == event.Guild.ID {
-			log.Println("Mumble-Discord bridge is active in new guild")
-			return
 		}
 	}
 }

--- a/main.go
+++ b/main.go
@@ -144,7 +144,6 @@ func main() {
 	Bridge.DiscordListener = &DiscordListener{
 		Bridge: Bridge,
 	}
-	Bridge.DiscordSession.AddHandler(Bridge.DiscordListener.ready)
 	Bridge.DiscordSession.AddHandler(Bridge.DiscordListener.messageCreate)
 	Bridge.DiscordSession.AddHandler(Bridge.DiscordListener.guildCreate)
 	Bridge.DiscordSession.AddHandler(Bridge.DiscordListener.voiceUpdate)


### PR DESCRIPTION
This PR swaps the GUILDCREATE and READY discord event handlers; it turns out when I initially wrote it on my end I got the two event types confused. The READY event does NOT contain initial voice state information, so initial setup hasn't been working this whole time. I fixed this in one of my own branches but was still testing some other stuff.

I also re-added the user count for Mumble. This is populated by a MumblePing as opposed to the mumbleUsers map, which only contains data when the bridge is actively connected to mumble. Without that auto-mode didn't work since the bridge never saw anyone connect to Mumble. This also meant I re-closed the Die channel since otherwise the bridge was failing to clean up properly and would also segfault.

If you were in the middle of doing something regarding the mumble/die chan stuff I can drop that commit. Mostly wanted to merge the discord change since that was my bad and actively doing the wrong behaviour.