### PR TITLE
support nested mumble channel, add debug toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Usage of ./mumble-discord-bridge:
   -mumble-address string
     	MUMBLE_ADDRESS, mumble server address, example example.com, required
   -mumble-channel string
-    	MUMBLE_CHANNEL, mumble channel to start in, optional
+    	MUMBLE_CHANNEL, mumble channel to start in, using '/' to seperate nested channels, optional
   -mumble-disable-text
     	MUMBLE_DISABLE_TEXT, disable sending text to mumble, (default false)
   -mumble-insecure
@@ -40,6 +40,8 @@ Usage of ./mumble-discord-bridge:
     	MUMBLE_USERNAME, mumble username, (default: discord) (default "Discord")
   -nice
     	NICE, whether the bridge should automatically try to 'nice' itself, (default false)
+  -debug
+        DEBUG_LEVEL,  DISCORD debug level, optional (default: 1)
 ```
 
 The bridge can be run with the follow modes:

--- a/config.go
+++ b/config.go
@@ -24,7 +24,7 @@ type BridgeConfig struct {
 	MumbleConfig       *gumble.Config
 	MumbleAddr         string
 	MumbleInsecure     bool
-	MumbleChannel      string
+	MumbleChannel      []string
 	MumbleDisableText  bool
 	Command            string
 	GID                string

--- a/main.go
+++ b/main.go
@@ -8,6 +8,7 @@ import (
 	"os/signal"
 	"runtime/pprof"
 	"strconv"
+	"strings"
 	"syscall"
 	"time"
 
@@ -99,7 +100,7 @@ func main() {
 			// MumbleConfig:   config,
 			MumbleAddr:         *mumbleAddr + ":" + strconv.Itoa(*mumblePort),
 			MumbleInsecure:     *mumbleInsecure,
-			MumbleChannel:      *mumbleChannel,
+			MumbleChannel:      strings.Split(*mumbleChannel, "/"),
 			MumbleDisableText:  *mumbleDisableText,
 			Command:            *discordCommand,
 			GID:                *discordGID,

--- a/main.go
+++ b/main.go
@@ -39,7 +39,7 @@ func main() {
 	mumbleUsername := flag.String("mumble-username", lookupEnvOrString("MUMBLE_USERNAME", "Discord"), "MUMBLE_USERNAME, mumble username, (default: discord)")
 	mumblePassword := flag.String("mumble-password", lookupEnvOrString("MUMBLE_PASSWORD", ""), "MUMBLE_PASSWORD, mumble password, optional")
 	mumbleInsecure := flag.Bool("mumble-insecure", lookupEnvOrBool("MUMBLE_INSECURE", false), " MUMBLE_INSECURE, mumble insecure, optional")
-	mumbleChannel := flag.String("mumble-channel", lookupEnvOrString("MUMBLE_CHANNEL", ""), "MUMBLE_CHANNEL, mumble channel to start in, optional")
+	mumbleChannel := flag.String("mumble-channel", lookupEnvOrString("MUMBLE_CHANNEL", ""), "MUMBLE_CHANNEL, mumble channel to start in, using '/' to seperate nested channels, optional")
 	mumbleDisableText := flag.Bool("mumble-disable-text", lookupEnvOrBool("MUMBLE_DISABLE_TEXT", false), "MUMBLE_DISABLE_TEXT, disable sending text to mumble, (default false)")
 	discordToken := flag.String("discord-token", lookupEnvOrString("DISCORD_TOKEN", ""), "DISCORD_TOKEN, discord bot token, required")
 	discordGID := flag.String("discord-gid", lookupEnvOrString("DISCORD_GID", ""), "DISCORD_GID, discord gid, required")
@@ -48,6 +48,7 @@ func main() {
 	discordDisableText := flag.Bool("discord-disable-text", lookupEnvOrBool("DISCORD_DISABLE_TEXT", false), "DISCORD_DISABLE_TEXT, disable sending direct messages to discord, (default false)")
 	mode := flag.String("mode", lookupEnvOrString("MODE", "constant"), "MODE, [constant, manual, auto] determine which mode the bridge starts in, (default constant)")
 	nice := flag.Bool("nice", lookupEnvOrBool("NICE", false), "NICE, whether the bridge should automatically try to 'nice' itself, (default false)")
+	debug := flag.Int("debug-level", lookupEnvOrInt("DEBUG", 1), "DEBUG_LEVEL, Discord debug level, optional, (default 1)")
 
 	cpuprofile := flag.String("cpuprofile", "", "write cpu profile to `file`")
 
@@ -136,7 +137,7 @@ func main() {
 		return
 	}
 
-	Bridge.DiscordSession.LogLevel = 1
+	Bridge.DiscordSession.LogLevel = *debug
 	Bridge.DiscordSession.StateEnabled = true
 	Bridge.DiscordSession.Identify.Intents = discordgo.MakeIntent(discordgo.IntentsAllWithoutPrivileged)
 	Bridge.DiscordSession.ShouldReconnectOnError = true

--- a/mumble-handlers.go
+++ b/mumble-handlers.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"fmt"
 	"log"
 	"strings"
 
@@ -41,7 +40,7 @@ func (l *MumbleListener) mumbleUserChange(e *gumble.UserChangeEvent) {
 		log.Println("User connected to mumble " + e.User.Name)
 
 		if !l.Bridge.BridgeConfig.MumbleDisableText {
-			e.User.Send(fmt.Sprintf("Mumble-Discord-Bridge %v", version))
+			e.User.Send("Mumble-Discord-Bridge v" + version)
 
 			// Tell the user who is connected to discord
 			if len(l.Bridge.DiscordUsers) == 0 {

--- a/mumble-handlers.go
+++ b/mumble-handlers.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"log"
 	"strings"
 
@@ -13,12 +14,10 @@ type MumbleListener struct {
 }
 
 func (l *MumbleListener) mumbleConnect(e *gumble.ConnectEvent) {
-	if l.Bridge.BridgeConfig.MumbleChannel != "" {
-		//join specified channel
-		startingChannel := e.Client.Channels.Find(l.Bridge.BridgeConfig.MumbleChannel)
-		if startingChannel != nil {
-			e.Client.Self.Move(startingChannel)
-		}
+	//join specified channel
+	startingChannel := e.Client.Channels.Find(l.Bridge.BridgeConfig.MumbleChannel...)
+	if startingChannel != nil {
+		e.Client.Self.Move(startingChannel)
 	}
 }
 
@@ -42,7 +41,7 @@ func (l *MumbleListener) mumbleUserChange(e *gumble.UserChangeEvent) {
 		log.Println("User connected to mumble " + e.User.Name)
 
 		if !l.Bridge.BridgeConfig.MumbleDisableText {
-			e.User.Send("Mumble-Discord-Bridge v" + version)
+			e.User.Send(fmt.Sprintf("Mumble-Discord-Bridge %v", version))
 
 			// Tell the user who is connected to discord
 			if len(l.Bridge.DiscordUsers) == 0 {


### PR DESCRIPTION
- adds support for nested Mumble channels (use format "Parent/Child")
- creates config option for discord debug level (and future debug level)

Fixes #14