### PR TITLE
Tweak grammar when no users are in mumble

### DIFF
--- a/internal/bridge/bridge.go
+++ b/internal/bridge/bridge.go
@@ -259,7 +259,7 @@ func (b *BridgeState) DiscordStatusUpdate() {
 				b.MumbleUserCount = b.MumbleUserCount - 1
 			}
 			if b.MumbleUserCount == 0 {
-				status = "No users in Mumble"
+				status = "no users in Mumble"
 			} else {
 				if len(b.MumbleUsers) > 0 {
 					status = fmt.Sprintf("%v/%v users in Mumble\n", len(b.MumbleUsers), b.MumbleUserCount)


### PR DESCRIPTION
The former capitalized "No" looks bad since the bot adds "Listening to" before it. 

Refer to this screenshot:
![image](https://user-images.githubusercontent.com/1613137/144746957-b8b4f6c1-c1a0-463d-97fd-03bfa506568c.png)
