### PR TITLE
don't clear channel ID on auto toggle

### DIFF
--- a/internal/bridge/discord-handlers.go
+++ b/internal/bridge/discord-handlers.go
@@ -150,7 +150,6 @@ func (l *DiscordListener) MessageCreate(s *discordgo.Session, m *discordgo.Messa
 			go l.Bridge.AutoBridge()
 		} else {
 			l.Bridge.DiscordSession.ChannelMessageSend(m.ChannelID, "Auto mode disabled")
-			l.Bridge.DiscordChannelID = ""
 			l.Bridge.AutoChanDie <- true
 			l.Bridge.Mode = BridgeModeManual
 		}


### PR DESCRIPTION
fixes #35

the channelID is set on link or start so we shouldn't have to clear it. Keeping it set lets people unlink from the same voice channel it originally was linked to.

the option option is to simply not require the unlink command to be sent by someone currently in voice.