### PR TITLE
openbsd default kernel works

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,11 +170,6 @@ go install github.com/goreleaser/goreleaser@latest
 goreleaser build --skip-validate --rm-dist --single-target --auto-snapshot
 ```
 
-### OpenBSD Users
-
-OpenBSD users should consider compiling a custom kernel to use 1000 ticks for the best possible performance.
-See [issue 20](https://github.com/Stieneee/mumble-discord-bridge/issues/20) for the latest discussion about this topic.
-
 ## Jitter Buffer
 
 The bridge implements simple jitter buffers that attempt to compensate for network, OS and hardware related jitter.


### PR DESCRIPTION
userland programs have improved in speed so the default OpenBSD kernel (100 Hz) works. it is no longer necessary to compile a custom 1000 Hz kernel.