### PR TITLE
Nightly/discordgo

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,37 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/go
+{
+	"name": "Go",
+	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+	"image": "mcr.microsoft.com/devcontainers/go:1-1.22-bookworm",
+
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	// "features": {},
+
+	// Configure tool-specific properties.
+	"customizations": {
+		// Configure properties specific to VS Code.
+		"vscode": {
+			"settings": {},
+			"extensions": []
+		}
+	},
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [9000],
+
+	// Use 'portsAttributes' to set default properties for specific forwarded ports. 
+	// More info: https://containers.dev/implementors/json_reference/#port-attributes
+	"portsAttributes": {
+		"9000": {
+			"label": "Hello Remote World",
+			"onAutoForward": "notify"
+		}
+	},
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	"postCreateCommand": "sudo apt update && sudo apt install -y libopus-dev pkg-config",
+
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
+}

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -16,6 +16,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
+          submodules: true
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -23,12 +23,12 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 
-      - name: Login to Docker Hub
-        uses: docker/login-action@v2
-        with:
-          registry: registry.hub.docker.com
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
+      # - name: Login to Docker Hub
+      #   uses: docker/login-action@v2
+      #   with:
+      #     registry: registry.hub.docker.com
+      #     username: ${{ secrets.DOCKER_USERNAME }}
+      #     password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v2
@@ -41,9 +41,10 @@ jobs:
         id: meta
         uses: docker/metadata-action@v4
         with:
-          images: |
-            stieneee/mumble-discord-bridge
-            ghcr.io/${{ github.repository }}
+          # images: |
+          #   ${{ github.repository }}
+          #   ghcr.io/${{ github.repository }}
+          images: ghcr.io/${{ github.repository }}
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -34,7 +34,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v4
         with:
           version: latest
-          args: build --clean --skip-validate
+          args: build --clean --skip=validate
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ LICENSES
 LICENSES.zip
 mumble-dsicrod-bridge
 dist/
+.vscode/settings.json

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "libs/discordgo"]
+	path = libs/discordgo
+	url = https://github.com/bwmarrin/discordgo.git

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,4 +1,4 @@
-version: 2
+version: 1
 
 project_name: mumble-discord-bridge
 

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,17 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Launch Mumble-Discord-Bridge",
+            "type": "go",
+            "request": "launch",
+            "mode": "auto",
+            "program": "${workspaceFolder}/cmd/mumble-discord-bridge",
+            "env": {
+                "CGO_ENABLED": "1"
+            },
+            "buildFlags": "-tags=netgo",
+            "cwd": "${workspaceFolder}"
+        }
+    ]
+}

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ COPY . .
 RUN apt update && apt install -y libopus-dev
 RUN go install github.com/goreleaser/goreleaser@latest
 RUN go install github.com/google/go-licenses@latest
-RUN goreleaser build --skip-validate
+RUN goreleaser build --skip=validate
 RUN go-licenses save ./cmd/mumble-discord-bridge --force --save_path="./dist/LICENSES"
 
 # Stage 2

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ dev-race: $(GOFILES) .goreleaser.yml
 	go run -race ./cmd/mumble-discord-bridge
 
 dev-profile: $(GOFILES) .goreleaser.yml
-	goreleaser build --skip-validate --clean --single-target --snapshot && ./dist/mumble-discord-bridge_linux_amd64_v1/mumble-discord-bridge -cpuprofile cpu.prof
+	goreleaser build --skip=validate --clean --single-target --snapshot && ./dist/mumble-discord-bridge_linux_amd64_v1/mumble-discord-bridge -cpuprofile cpu.prof
 
 test-chart: SHELL:=/bin/bash 
 test-chart:

--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ Ensure the opus library is installed.
 
 ```bash
 go install github.com/goreleaser/goreleaser@latest
-goreleaser build --skip-validate --rm-dist --single-target
+goreleaser build --skip=validate --rm-dist --single-target
 ```
 
 ### OpenBSD Users

--- a/cmd/mumble-discord-bridge/main.go
+++ b/cmd/mumble-discord-bridge/main.go
@@ -224,7 +224,8 @@ func main() {
 		discordgo.IntentsGuildMessages |
 		discordgo.IntentsGuildMessageReactions |
 		discordgo.IntentsDirectMessages |
-		discordgo.IntentsDirectMessageReactions)
+		discordgo.IntentsDirectMessageReactions |
+		discordgo.IntentsMessageContent)
 	b.DiscordSession.LogLevel = *debug
 	b.DiscordSession.StateEnabled = true
 	b.DiscordSession.Identify.Intents = intents

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,8 @@ require (
 	github.com/stieneee/tickerct v0.0.0-20210420020607-d1b092aa40e9
 )
 
+replace github.com/bwmarrin/discordgo => ./libs/discordgo
+
 require (
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect


### PR DESCRIPTION
Hi! 
I made some fixes in my own fork. Let me know if you want anything from this draft PR merged and I can create separate PR(s). 

Changes I made:
- Add bwmarring/discordgo as a submodule
  The current release of `bwmarring/discordgo` does not load any channels from the guild when initializing the state, from what I could tell. Since there's no alpha/nightly release of discordgo, I added the repo as a git submodule pointing to the latest commit, and included it as a lib.
- Update build-docker.yml to fetch with submodules
- Add devcontainer.json
  I'm developing on Windows and the source code as is does not compile due to `syscalls`, so I set up a devcontainer to develop in.
- Add .vscode/launch.json
  I'm also developing in vscode.
- Add MessageContent intent to discord client
  This intent is needed for the Discord bot to read text commands from channels. Without the intent, most messages, with some exceptions, will be received with no content by the bot. More info in the [Discord docs](https://discord.com/developers/docs/events/gateway#message-content-intent)
- Set version:1 in .goreleaser.yaml
  The version of goreleaser installed in the docker image is v1.
  The v2 configuration only works with `goreleaser@v2latest`, but which requires `golang 1.24`.
- Replace deprecated "--skip-validate" with "--skip=validate"
  Just something goreleaser was complaining about.
- Disable push to docker hub
  It was easier to just use github's CR with the credentials available in the repo instead of setting up docker hub credentials. 
  This is not meant to be merged in.   
