### PR TITLE
Add Sentry error tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,8 @@ Note boolean vales are flags when set via command line. example `-mumble-insecur
 | MUMBLE_BOT                 | -mumble-bot                 | flag   | false            | exclude bot from mumble user count, optional, requires mumble v1.5 or later                                                    |
 | PROMETHEUS_ENABLE          | -prometheus-enable          | flag   | false            | enable prometheus metrics                                                                                                      |
 | PROMETHEUS_PORT            | -prometheus-port            | int    | 9559             | prometheus metrics port                                                                                                        |
+| SENTRY_DSN                 | -sentry-dsn                 | string | ""               | Sentry error tracking DSN, optional                                                                                            |
+| SENTRY_ENVIRONMENT         | -sentry-environment         | string | "production"    | Sentry environment name                                                                                                       |
 | TO_DISCORD_BUFFER          | -to-discord-buffer          | int    | 50               | jitter buffer from Mumble to Discord to absorb timing issues related to network, OS and hardware quality. (Increments of 10ms) |
 | TO_MUMBLE_BUFFER           | -to-mumble-buffer           | int    | 50               | jitter buffer from Discord to Mumble to absorb timing issues related to network, OS and hardware quality. (Increments of 10ms) |
 

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.24.0
 
 require (
 	github.com/bwmarrin/discordgo v0.29.1-0.20251229161010-9f6aa8159fc6
+	github.com/getsentry/sentry-go v0.30.0
 	github.com/joho/godotenv v1.5.1
 	github.com/prometheus/client_golang v1.23.0
 	github.com/rs/zerolog v1.30.0


### PR DESCRIPTION
## Summary

Add Sentry error tracking to the mumble-discord-bridge Go application for production error monitoring.

## Changes

- Add  dependency
- Add  function with DSN and environment configuration
- Add CLI flags: , 
- Add panic recovery to capture unhandled panics
- Flush Sentry on graceful shutdown
- Update README with SENTRY_DSN and SENTRY_ENVIRONMENT env vars

## Usage

Set the following environment variables:
-  - Your Sentry DSN (e.g., from Sentry project settings)
-  - Environment name (defaults to "production")

Or use CLI flags:
```bash
./mumble-discord-bridge -sentry-dsn="https://..." -sentry-environment=production
```

## Testing

The integration can be tested by:
1. Setting a valid SENTRY_DSN
2. Triggering a panic or error in the application
3. Verifying errors appear in Sentry dashboard