### PR TITLE
fix: redact sensitive config values in logs

### DIFF
--- a/cmd/mumble-discord-bridge/config.go
+++ b/cmd/mumble-discord-bridge/config.go
@@ -50,7 +50,11 @@ func lookupEnvOrBool(key string, defaultVal bool) bool {
 func getConfig(fs *flag.FlagSet) []string {
 	cfg := make([]string, 0, 10)
 	fs.VisitAll(func(f *flag.Flag) {
-		cfg = append(cfg, fmt.Sprintf("%s:%q", f.Name, f.Value.String()))
+		value := f.Value.String()
+		if value != "" && (f.Name == "discord-token" || f.Name == "mumble-password") {
+			value = "[REDACTED]"
+		}
+		cfg = append(cfg, fmt.Sprintf("%s:%q", f.Name, value))
 	})
 
 	return cfg

--- a/cmd/mumble-discord-bridge/config_test.go
+++ b/cmd/mumble-discord-bridge/config_test.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"flag"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestGetConfig(t *testing.T) {
+	t.Run("redacts non-empty sensitive final values", func(t *testing.T) {
+		const (
+			nonRealDefaultTokenSentinel = "NON_REAL_DEFAULT_TOKEN_SENTINEL"
+			nonRealDefaultPassSentinel  = "NON_REAL_DEFAULT_PASSWORD_SENTINEL"
+			nonRealCLITokenSentinel     = "NON_REAL_CLI_TOKEN_SENTINEL"
+			nonRealCLIPassSentinel      = "NON_REAL_CLI_PASSWORD_SENTINEL"
+		)
+
+		fs := flag.NewFlagSet("test", flag.ContinueOnError)
+		fs.String("discord-token", nonRealDefaultTokenSentinel, "")
+		fs.String("mumble-password", nonRealDefaultPassSentinel, "")
+		fs.String("discord-gid", "guild-123", "")
+		fs.String("discord-cid", "channel-456", "")
+		fs.Int("to-discord-buffer", 70, "")
+		fs.Int("to-mumble-buffer", 80, "")
+		fs.String("mode", "manual", "")
+		if err := fs.Parse([]string{
+			"-discord-token=" + nonRealCLITokenSentinel,
+			"-mumble-password=" + nonRealCLIPassSentinel,
+		}); err != nil {
+			t.Fatalf("parse CLI overrides: %v", err)
+		}
+
+		got := getConfig(fs)
+		want := []string{
+			`discord-cid:"channel-456"`,
+			`discord-gid:"guild-123"`,
+			`discord-token:"[REDACTED]"`,
+			`mode:"manual"`,
+			`mumble-password:"[REDACTED]"`,
+			`to-discord-buffer:"70"`,
+			`to-mumble-buffer:"80"`,
+		}
+		if len(got) != 7 {
+			t.Fatalf("getConfig returned %d items, want all 7 flags: %v", len(got), got)
+		}
+		if !reflect.DeepEqual(got, want) {
+			t.Fatalf("getConfig() = %v, want %v", got, want)
+		}
+
+		output := strings.Join(got, "\n")
+		for _, sentinel := range []string{
+			nonRealDefaultTokenSentinel,
+			nonRealDefaultPassSentinel,
+			nonRealCLITokenSentinel,
+			nonRealCLIPassSentinel,
+		} {
+			if strings.Contains(output, sentinel) {
+				t.Errorf("getConfig output contains non-real secret sentinel %q", sentinel)
+			}
+		}
+	})
+
+	t.Run("preserves empty sensitive values", func(t *testing.T) {
+		fs := flag.NewFlagSet("test", flag.ContinueOnError)
+		fs.String("discord-token", "", "")
+		fs.String("mumble-password", "", "")
+
+		got := getConfig(fs)
+		want := []string{`discord-token:""`, `mumble-password:""`}
+		if !reflect.DeepEqual(got, want) {
+			t.Fatalf("getConfig() = %v, want %v", got, want)
+		}
+	})
+}


### PR DESCRIPTION
## Summary

- redact non-empty Discord bot tokens and Mumble passwords from startup config logs
- preserve empty sensitive values and all non-sensitive config output
- add regression coverage for defaults, CLI overrides, ordering, and output count

## Security impact

The startup config logger currently serializes every parsed flag value, which can expose credentials supplied through environment variables, CLI flags, or .env. This change retains the config log while replacing sensitive values with a fixed [REDACTED] marker.

## Validation

Validated on Ubuntu 24.04 with Go 1.25.7, Opus 1.4, and libdave v1.1.1:

- go test -race -run '^TestGetConfig' ./cmd/mumble-discord-bridge`n- go test -race -v ./...`n- go test -race -count=10 ./internal/bridge ./pkg/bridgelib`n- build completed successfully
- environment, CLI override, and .env startup probes confirmed both sensitive values are absent and redaction markers are present
- git diff --check and a redacted secret scan passed

No real credentials were used during testing.